### PR TITLE
Fix support for Diners Club

### DIFF
--- a/PaymentezSDK/PaymentezAddNativeViewController.swift
+++ b/PaymentezSDK/PaymentezAddNativeViewController.swift
@@ -768,7 +768,7 @@ extension PaymentezAddNativeViewController: MaskedTextFieldDelegateListener
             self.paymentezCard.cardNumber = self.cardField.text?.replacingOccurrences(of: "-", with: "")
             if value.count >= 6  && value.count <= 10 && self.cardType == .notSupported { // check bin
                 self.validateCard(value)
-                if value.count < 15 {
+                if value.count < 14 {
                     self.cardField.errorMessage = "Invalid".localized
                 }
             } else if value.count < 6 {
@@ -777,7 +777,7 @@ extension PaymentezAddNativeViewController: MaskedTextFieldDelegateListener
                 self.toggleTuya(show:false)
                 
             }
-            if value.count < 15 {
+            if value.count < 14 {
                 self.cardField.errorMessage = "Invalid".localized
             }
             

--- a/PaymentezSDK/PaymentezCard.swift
+++ b/PaymentezSDK/PaymentezCard.swift
@@ -27,7 +27,7 @@ public enum PaymentezCardType: String
 let REGEX_AMEX = "^3[47][0-9]{5,}$"
 let REGEX_VISA = "^4[0-9]{6,}$"
 let REGEX_MASTERCARD = "^5[1-5][0-9]{5,}$"
-let REGEX_DINERS = "^3(?:0[0-5]|[68][0-9])[0-9]{4,}$"
+let REGEX_DINERS = "^3(?:0[0-5]|[68][0-9])[0-9]{11}$"
 let REGEX_DISCOVER = "^65[4-9][0-9]{13}|64[4-9][0-9]{13}|6011[0-9]{12}|(622(?:12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|9[01][0-9]|92[0-5])[0-9]{10})$"
 let REGEX_JCB = "^(?:2131|1800|35[0-9]{3})[0-9]{11}$"
 
@@ -226,7 +226,7 @@ public typealias ValidationCallback = (_ cardType: PaymentezCardType, _ cardImag
     
     public static func getTypeCard(_ cardNumber:String) -> PaymentezCardType
     {
-        if cardNumber.count < 15  || cardNumber.count > 16
+        if cardNumber.count < 14  || cardNumber.count > 16
         {
             return PaymentezCardType.notSupported
         }


### PR DESCRIPTION
Diners Club card have 14 numbers. In Android SDK is correct: https://github.com/paymentez/paymentez-android/blob/master/paymentez-android/src/main/java/com/paymentez/android/util/CardUtils.java#L17.

Fixes #38 .